### PR TITLE
fix #40: optimize Ruby's regex pattern 

### DIFF
--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -20,7 +20,7 @@ export const Ruby: LanguagePattern[] = [
   // elsif keyword
   { pattern: /elsif/, type: 'keyword.control' },
   // do
-  { pattern: /(do\s*\|(\w+(,\s*\w+)?)+\|)/, type: 'keyword.control' },
+  { pattern: /do\s*[|]\w+(,\s*\w+)*[|]/, type: 'keyword.control' },
   // for loop
   { pattern: /for (\w+|\(?\w+,\s*\w+\)?) in (.+)/, type: 'keyword.control' },
   // nil keyword


### PR DESCRIPTION
fix #40 

Nested quantifier is a common cause of exponential backtracking. In `/(do\s*[|](\w+(,\s*\w+)?)+[|])/`, there's a nested quantifier 3 levels deep: `(\w+(,\s*\w+)?)+`.
I replaced it with `\w+(,\s*\w+)*` so it became 2 levels deep. 

The test on https://regex101.com/r/yT5xg0/1/debugger shows that it no longer causes exponential backtracking on string: "do|aaa", but rather linear.

Other change:
- removed the first capture group because it seems to serve no purpose.
- replaced `\|` with `[|]` for readability. 

