### PR TITLE
refactor: clean up flourite just to have one returned object

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ Detects a programming language from a given string.
 - Built-in support for CommonJS and ESM format
 - Built-in Typescript typings
 - No external dependencies
-- 150 test cases and growing!
+- 200 test cases and growing!
 
 ## Detectable languages
 
-| Languages |            |        |      |
-| --------- | ---------- | ------ | ---- |
-| C         | Go         | Kotlin | Ruby |
-| C++       | HTML       | Lua    | Rust |
-| C#        | Java       | Pascal | SQL  |
-| Clojure   | Javascript | PHP    | YAML |
-| CSS       | Julia      | Python |      |
+| Languages |            |        |        |
+| --------- | ---------- | ------ | ------ |
+| C         | Dockerfile | Julia  | Python |
+| C++       | Go         | Kotlin | Ruby   |
+| C#        | HTML       | Lua    | Rust   |
+| Clojure   | Java       | Pascal | SQL    |
+| CSS       | Javascript | PHP    | Yaml   |
 
 ## Install
 
@@ -39,45 +39,44 @@ or via a CDN (unpkg or jsdelivr)
 ```js
 import flourite from 'flourite';
 
-const code = flourite('console.log("Hello World");'); // => Javascript
-```
+const code = flourite('printf("Hello World");');
 
-You could supply options to make see numbers of points for a certain language:
-
-```js
-import flourite from 'flourite';
-
-const code = flourite('printf("Hello World")', { statistics: true });
-
-// code.detected = 'C'
-// code.statistics = {
-//   C: 5,
-//   Clojure: 0,
-//   'C++': 0,
-//   'C#': 0,
-//   CSS: 0,
-//   Go: 0,
-//   HTML: 0,
-//   Java: 0,
-//   Javascript: 0,
-//   Julia: 0,
-//   Kotlin: 0,
-//   Lua: -20,
-//   Pascal: 0,
-//   PHP: 0,
-//   Python: 0,
-//   Ruby: 0,
-//   Rust: 0,
-//   SQL: 0,
-//   Unknown: 1,
-//   YAML: 0
+// {
+//   language: 'C',
+//   statistics: {
+//     C: 5,
+//     Clojure: 0,
+//     'C++': 0,
+//     'C#': 0,
+//     CSS: 0,
+//     Dockerfile: 0,
+//     Go: 0,
+//     HTML: 0,
+//     Java: 0,
+//     Javascript: 0,
+//     Julia: 0,
+//     Kotlin: 0,
+//     Lua: -20,
+//     Pascal: 0,
+//     PHP: 0,
+//     Python: 0,
+//     Ruby: 0,
+//     Rust: 0,
+//     SQL: 0,
+//     YAML: 0,
+//     Unknown: 1
+//   },
+//   linesOfCode: 1
 // }
 ```
 
 Or if you want to integrate it with [Shiki](https://github.com/shikijs/shiki), you could pass:
 
 ```js
-const code = flourite('Console.WriteLine("Hello world!");', { shiki: true }); // => csharp
+flourite('Console.WriteLine("Hello world!");', { shiki: true }).language;
+// => csharp
+flourite('fn partition<T,F>(v: &mut [T], f: &F) -> usize ', { shiki: true }).language;
+// => rust
 ```
 
 If you want to handle `Unknown` value, you could pass:
@@ -90,24 +89,22 @@ const code = flourite("SELECT 'Hello world!' text FROM dual;", { noUnknown: true
 
 ```typescript
 import flourite from 'flourite';
-import type { Options, StatisticOutput } from 'flourite';
+import type { Options } from 'flourite';
 
 const flouriteOptions: Options = {
   heuristic: true,
-  statistics: true,
 };
 
-const code = flourite('print!({:?}, &v);', flouriteOptions) as StatisticOutput;
+const code = flourite('print!({:?}, &v);', flouriteOptions);
 ```
 
 ### Available Options
 
-| Key        | Type      | Default | Description                                                                                      |
-| ---------- | --------- | ------- | ------------------------------------------------------------------------------------------------ |
-| heuristic  | `boolean` | `true`  | Checks for codes on the top of the given input. Only checks when the lines of code is above 500. |
-| statistics | `boolean` | `false` | If `true`, will return the statistics of all the guessed language.                               |
-| shiki      | `boolean` | `false` | Straightforward compatibility with Shiki's language specification type                           |
-| noUnknown  | `boolean` | `false` | If `true`, will not output `Unknown` on detected and statistics result                           |
+| Key       | Type      | Default | Description                                                                                      |
+| --------- | --------- | ------- | ------------------------------------------------------------------------------------------------ | --- |
+| heuristic | `boolean` | `true`  | Checks for codes on the top of the given input. Only checks when the lines of code is above 500. |     |
+| shiki     | `boolean` | `false` | Straightforward compatibility with Shiki's language specification type                           |
+| noUnknown | `boolean` | `false` | If `true`, will not output `Unknown` on detected and statistics result                           |
 
 ## I'm here for Hacktoberfest, what can I do?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,23 +11,23 @@
       "devDependencies": {
         "@aldy505/kruonis": "^0.0.1",
         "@rollup/plugin-typescript": "^8.2.5",
-        "@types/node": "^16.6.1",
-        "@typescript-eslint/eslint-plugin": "^4.29.1",
-        "@typescript-eslint/parser": "^4.29.1",
-        "c8": "^7.8.0",
-        "esbuild": "^0.12.20",
+        "@types/node": "^16.10.3",
+        "@typescript-eslint/eslint-plugin": "^4.33.0",
+        "@typescript-eslint/parser": "^4.33.0",
+        "c8": "^7.10.0",
+        "esbuild": "^0.13.4",
         "esbuild-register": "^3.0.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-prettier": "^3.4.0",
-        "husky": "^7.0.1",
-        "prettier": "^2.3.2",
-        "rollup": "^2.56.2",
+        "eslint-plugin-prettier": "^4.0.0",
+        "husky": "^7.0.2",
+        "prettier": "^2.4.1",
+        "rollup": "^2.58.0",
         "rollup-plugin-terser": "^7.0.2",
         "tslib": "^2.3.1",
-        "typescript": "^4.3.5",
+        "typescript": "^4.4.3",
         "uvu": "^0.5.1",
-        "watchlist": "^0.2.3"
+        "watchlist": "^0.3.1"
       },
       "funding": {
         "url": "https://saweria.co/teknologiumum"
@@ -289,21 +289,22 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
-      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
+      "version": "16.10.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
+      "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-      "integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.29.1",
-        "@typescript-eslint/scope-manager": "4.29.1",
+        "@typescript-eslint/experimental-utils": "4.33.0",
+        "@typescript-eslint/scope-manager": "4.33.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
@@ -325,16 +326,25 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-      "integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -350,14 +360,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-      "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -377,13 +387,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-      "integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1"
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -394,9 +404,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-      "integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -407,13 +417,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-      "integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -434,12 +444,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-      "integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.29.1",
+        "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -497,9 +507,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -582,16 +592,16 @@
       "dev": true
     },
     "node_modules/c8": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.8.0.tgz",
-      "integrity": "sha512-x2Bx+IIEd608B1LmjiNQ/kizRPkCWo5XzuV57J9afPjAHSnYXALwbCSOkQ7cSaNXBNblfqcvdycj+klmL+j6yA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-7.10.0.tgz",
+      "integrity": "sha512-OAwfC5+emvA6R7pkYFVBTOtI5ruf9DahffGmIqUc9l6wEh0h7iAFP6dt/V9Ioqlr2zW5avX9U9/w1I4alTRHkA==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@istanbuljs/schema": "^0.1.2",
         "find-up": "^5.0.0",
         "foreground-child": "^2.0.0",
-        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-coverage": "^3.0.1",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.0.2",
         "rimraf": "^3.0.0",
@@ -780,14 +790,188 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.12.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.20.tgz",
-      "integrity": "sha512-u7+0qTo9Z64MD9PhooEngCmzyEYJ6ovFhPp8PLNh3UasR5Ihjv6HWVXqm8uHmasdQlpsAf0IsY4U0YVUfCpt4Q==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.4.tgz",
+      "integrity": "sha512-wMA5eUwpavTBiNl+It6j8OQuKVh69l6z4DKDLzoTIqC+gChnPpcmqdA8WNHptUHRnfyML+mKEQPlW7Mybj8gHg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
+      },
+      "optionalDependencies": {
+        "esbuild-android-arm64": "0.13.4",
+        "esbuild-darwin-64": "0.13.4",
+        "esbuild-darwin-arm64": "0.13.4",
+        "esbuild-freebsd-64": "0.13.4",
+        "esbuild-freebsd-arm64": "0.13.4",
+        "esbuild-linux-32": "0.13.4",
+        "esbuild-linux-64": "0.13.4",
+        "esbuild-linux-arm": "0.13.4",
+        "esbuild-linux-arm64": "0.13.4",
+        "esbuild-linux-mips64le": "0.13.4",
+        "esbuild-linux-ppc64le": "0.13.4",
+        "esbuild-openbsd-64": "0.13.4",
+        "esbuild-sunos-64": "0.13.4",
+        "esbuild-windows-32": "0.13.4",
+        "esbuild-windows-64": "0.13.4",
+        "esbuild-windows-arm64": "0.13.4"
       }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.4.tgz",
+      "integrity": "sha512-elDJt+jNyoHFId0/dKsuVYUPke3EcquIyUwzJCH17a3ERglN3A9aMBI5zbz+xNZ+FbaDNdpn0RaJHCFLbZX+fA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.4.tgz",
+      "integrity": "sha512-zJQGyHRAdZUXlRzbN7W+7ykmEiGC+bq3Gc4GxKYjjWTgDRSEly98ym+vRNkDjXwXYD3gGzSwvH35+MiHAtWvLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.4.tgz",
+      "integrity": "sha512-r8oYvAtqSGq8HNTZCAx4TdLE7jZiGhX9ooGi5AQAey37MA6XNaP8ZNlw9OCpcgpx3ryU2WctXwIqPzkHO7a8dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.4.tgz",
+      "integrity": "sha512-u9DRGkn09EN8+lCh6z7FKle7awi17PJRBuAKdRNgSo5ZrH/3m+mYaJK2PR2URHMpAfXiwJX341z231tSdVe3Yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.4.tgz",
+      "integrity": "sha512-q3B2k68Uf6gfjATjcK16DqxvjqRQkHL8aPoOfj4op+lSqegdXvBacB1d8jw8PxbWJ8JHpdTLdAVUYU80kotQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.4.tgz",
+      "integrity": "sha512-UUYJPHSiKAO8KoN3Ls/iZtgDLZvK5HarES96aolDPWZnq9FLx4dIHM/x2z4Rxv9IYqQ/DxlPoE2Co1UPBIYYeA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.4.tgz",
+      "integrity": "sha512-+RnohAKiiUW4UHLGRkNR1AnENW1gCuDWuygEtd4jxTNPIoeC7lbXGor7rtgjj9AdUzFgOEvAXyNNX01kJ8NueQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.4.tgz",
+      "integrity": "sha512-BH5gKve4jglS7UPSsfwHSX79I5agC/lm4eKoRUEyo8lwQs89frQSRp2Xup+6SFQnxt3md5EsKcd2Dbkqeb3gPA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.4.tgz",
+      "integrity": "sha512-+A188cAdd6QuSRxMIwRrWLjgphQA0LDAQ/ECVlrPVJwnx+1i64NjDZivoqPYLOTkSPIKntiWwMhhf0U5/RrPHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.4.tgz",
+      "integrity": "sha512-0xkwtPaUkG5xMTFGaQPe1AadSe5QAiQuD4Gix1O9k5Xo/U8xGIkw9UFUTvfEUeu71vFb6ZgsIacfP1NLoFjWNw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.4.tgz",
+      "integrity": "sha512-E1+oJPP7A+j23GPo3CEpBhGwG1bni4B8IbTA3/3rvzjURwUMZdcN3Fhrz24rnjzdLSHmULtOE4VsbT42h1Om4Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.4.tgz",
+      "integrity": "sha512-xEkI1o5HYxDzbv9jSox0EsDxpwraG09SRiKKv0W8pH6O3bt+zPSlnoK7+I7Q69tkvONkpIq5n2o+c55uq0X7cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
     },
     "node_modules/esbuild-register": {
       "version": "3.0.0",
@@ -800,6 +984,58 @@
       "peerDependencies": {
         "esbuild": ">=0.12 <1"
       }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.4.tgz",
+      "integrity": "sha512-bjXUMcODMnB6hQicLBBmmnBl7OMDyVpFahKvHGXJfDChIi5udiIRKCmFUFIRn+AUAKVlfrofRKdyPC7kBsbvGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ]
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.4.tgz",
+      "integrity": "sha512-z4CH07pfyVY0XF98TCsGmLxKCl0kyvshKDbdpTekW9f2d+dJqn5mmoUyWhpSVJ0SfYWJg86FoD9nMbbaMVyGdg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.4.tgz",
+      "integrity": "sha512-uVL11vORRPjocGLYam67rwFLd0LvkrHEs+JG+1oJN4UD9MQmNGZPa4gBHo6hDpF+kqRJ9kXgQSeDqUyRy0tj/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.4.tgz",
+      "integrity": "sha512-vA6GLvptgftRcDcWngD5cMlL4f4LbL8JjU2UMT9yJ0MT5ra6hdZNFWnOeOoEtY4GtJ6OjZ0i+81sTqhAB0fMkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -892,9 +1128,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
       "dev": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0"
@@ -903,8 +1139,8 @@
         "node": ">=6.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=5.0.0",
-        "prettier": ">=1.13.0"
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "eslint-config-prettier": {
@@ -1119,9 +1355,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1344,9 +1580,9 @@
       "dev": true
     },
     "node_modules/husky": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.1.tgz",
-      "integrity": "sha512-gceRaITVZ+cJH9sNHqx5tFwbzlLCVxtVZcusME8JYQ8Edy5mpGDOqD8QBCdMhpyo9a+JXddnujQ4rpY2Ff9SJA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
+      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
@@ -1466,9 +1702,9 @@
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz",
+      "integrity": "sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -1842,9 +2078,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -1990,9 +2226,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.56.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
-      "integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.0.tgz",
+      "integrity": "sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2370,9 +2606,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2431,9 +2667,9 @@
       }
     },
     "node_modules/watchlist": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/watchlist/-/watchlist-0.2.3.tgz",
-      "integrity": "sha512-xStuPg489QXZbRirnmIMo7OaKFnGkvTQn7tCUC/sVmVVEvDQQnnVl/k9D5yg3nXgpebgPHpfApBLHMpEbAqvSQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/watchlist/-/watchlist-0.3.1.tgz",
+      "integrity": "sha512-m5r4bzxJ9eg07TT/O0Q49imFPD45ZTuQ3kaHwSpUJj1QwVd3pzit4UYOmySdmAP5Egkz6mB6hcAPuPfhIbNo0g==",
       "dev": true,
       "dependencies": {
         "mri": "^1.1.5"
@@ -2753,76 +2989,85 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
-      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
+      "version": "16.10.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
+      "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-      "integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.29.1",
-        "@typescript-eslint/scope-manager": "4.29.1",
+        "@typescript-eslint/experimental-utils": "4.33.0",
+        "@typescript-eslint/scope-manager": "4.33.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-      "integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-      "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-      "integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1"
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-      "integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-      "integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -2831,12 +3076,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-      "integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
+        "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -2872,9 +3117,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -2939,16 +3184,16 @@
       "dev": true
     },
     "c8": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.8.0.tgz",
-      "integrity": "sha512-x2Bx+IIEd608B1LmjiNQ/kizRPkCWo5XzuV57J9afPjAHSnYXALwbCSOkQ7cSaNXBNblfqcvdycj+klmL+j6yA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-7.10.0.tgz",
+      "integrity": "sha512-OAwfC5+emvA6R7pkYFVBTOtI5ruf9DahffGmIqUc9l6wEh0h7iAFP6dt/V9Ioqlr2zW5avX9U9/w1I4alTRHkA==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@istanbuljs/schema": "^0.1.2",
         "find-up": "^5.0.0",
         "foreground-child": "^2.0.0",
-        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-coverage": "^3.0.1",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.0.2",
         "rimraf": "^3.0.0",
@@ -3093,10 +3338,112 @@
       }
     },
     "esbuild": {
-      "version": "0.12.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.20.tgz",
-      "integrity": "sha512-u7+0qTo9Z64MD9PhooEngCmzyEYJ6ovFhPp8PLNh3UasR5Ihjv6HWVXqm8uHmasdQlpsAf0IsY4U0YVUfCpt4Q==",
-      "dev": true
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.4.tgz",
+      "integrity": "sha512-wMA5eUwpavTBiNl+It6j8OQuKVh69l6z4DKDLzoTIqC+gChnPpcmqdA8WNHptUHRnfyML+mKEQPlW7Mybj8gHg==",
+      "dev": true,
+      "requires": {
+        "esbuild-android-arm64": "0.13.4",
+        "esbuild-darwin-64": "0.13.4",
+        "esbuild-darwin-arm64": "0.13.4",
+        "esbuild-freebsd-64": "0.13.4",
+        "esbuild-freebsd-arm64": "0.13.4",
+        "esbuild-linux-32": "0.13.4",
+        "esbuild-linux-64": "0.13.4",
+        "esbuild-linux-arm": "0.13.4",
+        "esbuild-linux-arm64": "0.13.4",
+        "esbuild-linux-mips64le": "0.13.4",
+        "esbuild-linux-ppc64le": "0.13.4",
+        "esbuild-openbsd-64": "0.13.4",
+        "esbuild-sunos-64": "0.13.4",
+        "esbuild-windows-32": "0.13.4",
+        "esbuild-windows-64": "0.13.4",
+        "esbuild-windows-arm64": "0.13.4"
+      }
+    },
+    "esbuild-android-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.4.tgz",
+      "integrity": "sha512-elDJt+jNyoHFId0/dKsuVYUPke3EcquIyUwzJCH17a3ERglN3A9aMBI5zbz+xNZ+FbaDNdpn0RaJHCFLbZX+fA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.4.tgz",
+      "integrity": "sha512-zJQGyHRAdZUXlRzbN7W+7ykmEiGC+bq3Gc4GxKYjjWTgDRSEly98ym+vRNkDjXwXYD3gGzSwvH35+MiHAtWvLA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.4.tgz",
+      "integrity": "sha512-r8oYvAtqSGq8HNTZCAx4TdLE7jZiGhX9ooGi5AQAey37MA6XNaP8ZNlw9OCpcgpx3ryU2WctXwIqPzkHO7a8dg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.4.tgz",
+      "integrity": "sha512-u9DRGkn09EN8+lCh6z7FKle7awi17PJRBuAKdRNgSo5ZrH/3m+mYaJK2PR2URHMpAfXiwJX341z231tSdVe3Yw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.4.tgz",
+      "integrity": "sha512-q3B2k68Uf6gfjATjcK16DqxvjqRQkHL8aPoOfj4op+lSqegdXvBacB1d8jw8PxbWJ8JHpdTLdAVUYU80kotQXA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.4.tgz",
+      "integrity": "sha512-UUYJPHSiKAO8KoN3Ls/iZtgDLZvK5HarES96aolDPWZnq9FLx4dIHM/x2z4Rxv9IYqQ/DxlPoE2Co1UPBIYYeA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.4.tgz",
+      "integrity": "sha512-+RnohAKiiUW4UHLGRkNR1AnENW1gCuDWuygEtd4jxTNPIoeC7lbXGor7rtgjj9AdUzFgOEvAXyNNX01kJ8NueQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.4.tgz",
+      "integrity": "sha512-BH5gKve4jglS7UPSsfwHSX79I5agC/lm4eKoRUEyo8lwQs89frQSRp2Xup+6SFQnxt3md5EsKcd2Dbkqeb3gPA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.4.tgz",
+      "integrity": "sha512-+A188cAdd6QuSRxMIwRrWLjgphQA0LDAQ/ECVlrPVJwnx+1i64NjDZivoqPYLOTkSPIKntiWwMhhf0U5/RrPHQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.4.tgz",
+      "integrity": "sha512-0xkwtPaUkG5xMTFGaQPe1AadSe5QAiQuD4Gix1O9k5Xo/U8xGIkw9UFUTvfEUeu71vFb6ZgsIacfP1NLoFjWNw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.4.tgz",
+      "integrity": "sha512-E1+oJPP7A+j23GPo3CEpBhGwG1bni4B8IbTA3/3rvzjURwUMZdcN3Fhrz24rnjzdLSHmULtOE4VsbT42h1Om4Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.4.tgz",
+      "integrity": "sha512-xEkI1o5HYxDzbv9jSox0EsDxpwraG09SRiKKv0W8pH6O3bt+zPSlnoK7+I7Q69tkvONkpIq5n2o+c55uq0X7cw==",
+      "dev": true,
+      "optional": true
     },
     "esbuild-register": {
       "version": "3.0.0",
@@ -3106,6 +3453,34 @@
       "requires": {
         "jsonc-parser": "^3.0.0"
       }
+    },
+    "esbuild-sunos-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.4.tgz",
+      "integrity": "sha512-bjXUMcODMnB6hQicLBBmmnBl7OMDyVpFahKvHGXJfDChIi5udiIRKCmFUFIRn+AUAKVlfrofRKdyPC7kBsbvGQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.4.tgz",
+      "integrity": "sha512-z4CH07pfyVY0XF98TCsGmLxKCl0kyvshKDbdpTekW9f2d+dJqn5mmoUyWhpSVJ0SfYWJg86FoD9nMbbaMVyGdg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.4.tgz",
+      "integrity": "sha512-uVL11vORRPjocGLYam67rwFLd0LvkrHEs+JG+1oJN4UD9MQmNGZPa4gBHo6hDpF+kqRJ9kXgQSeDqUyRy0tj/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.4.tgz",
+      "integrity": "sha512-vA6GLvptgftRcDcWngD5cMlL4f4LbL8JjU2UMT9yJ0MT5ra6hdZNFWnOeOoEtY4GtJ6OjZ0i+81sTqhAB0fMkg==",
+      "dev": true,
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -3194,9 +3569,9 @@
       "requires": {}
     },
     "eslint-plugin-prettier": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -3342,9 +3717,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -3511,9 +3886,9 @@
       "dev": true
     },
     "husky": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.1.tgz",
-      "integrity": "sha512-gceRaITVZ+cJH9sNHqx5tFwbzlLCVxtVZcusME8JYQ8Edy5mpGDOqD8QBCdMhpyo9a+JXddnujQ4rpY2Ff9SJA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
+      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
       "dev": true
     },
     "ignore": {
@@ -3597,9 +3972,9 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz",
+      "integrity": "sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==",
       "dev": true
     },
     "istanbul-lib-report": {
@@ -3885,9 +4260,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -3976,9 +4351,9 @@
       }
     },
     "rollup": {
-      "version": "2.56.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
-      "integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.0.tgz",
+      "integrity": "sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -4257,9 +4632,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "uri-js": {
@@ -4302,9 +4677,9 @@
       }
     },
     "watchlist": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/watchlist/-/watchlist-0.2.3.tgz",
-      "integrity": "sha512-xStuPg489QXZbRirnmIMo7OaKFnGkvTQn7tCUC/sVmVVEvDQQnnVl/k9D5yg3nXgpebgPHpfApBLHMpEbAqvSQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/watchlist/-/watchlist-0.3.1.tgz",
+      "integrity": "sha512-m5r4bzxJ9eg07TT/O0Q49imFPD45ZTuQ3kaHwSpUJj1QwVd3pzit4UYOmySdmAP5Egkz6mB6hcAPuPfhIbNo0g==",
       "dev": true,
       "requires": {
         "mri": "^1.1.5"

--- a/package.json
+++ b/package.json
@@ -69,22 +69,22 @@
   "devDependencies": {
     "@aldy505/kruonis": "^0.0.1",
     "@rollup/plugin-typescript": "^8.2.5",
-    "@types/node": "^16.6.1",
-    "@typescript-eslint/eslint-plugin": "^4.29.1",
-    "@typescript-eslint/parser": "^4.29.1",
-    "c8": "^7.8.0",
-    "esbuild": "^0.12.20",
+    "@types/node": "^16.10.3",
+    "@typescript-eslint/eslint-plugin": "^4.33.0",
+    "@typescript-eslint/parser": "^4.33.0",
+    "c8": "^7.10.0",
+    "esbuild": "^0.13.4",
     "esbuild-register": "^3.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-prettier": "^3.4.0",
-    "husky": "^7.0.1",
-    "prettier": "^2.3.2",
-    "rollup": "^2.56.2",
+    "eslint-plugin-prettier": "^4.0.0",
+    "husky": "^7.0.2",
+    "prettier": "^2.4.1",
+    "rollup": "^2.58.0",
     "rollup-plugin-terser": "^7.0.2",
     "tslib": "^2.3.1",
-    "typescript": "^4.3.5",
+    "typescript": "^4.4.3",
     "uvu": "^0.5.1",
-    "watchlist": "^0.2.3"
+    "watchlist": "^0.3.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { LanguagePattern, LanguagePoints, Options, StatisticOutput } from './types';
+import type { LanguagePattern, LanguagePoints, Options, DetectedLanguage } from './types';
 import { C } from './languages/c';
 import { Clojure } from './languages/clojure';
 import { CPP } from './languages/cpp';
@@ -49,7 +49,7 @@ const languages: Record<string, LanguagePattern[]> = {
  * Detects a programming language from a given string.
  * @param {String} snippet The code we're guessing
  * @param {Options} options Options
- * @returns {String|StatisticOutput} A String or a StatisticOutput format if `statistics: true`
+ * @returns {DetectedLanguage} An object of DetectedLanguage
  * @example
  * ```js
  * import flourite from 'flourite';
@@ -59,8 +59,8 @@ const languages: Record<string, LanguagePattern[]> = {
  */
 function flourite(
   snippet: string,
-  options: Options = { heuristic: true, statistics: false, shiki: false, noUnknown: false },
-): StatisticOutput & string {
+  options: Options = { heuristic: true, shiki: false, noUnknown: false },
+): DetectedLanguage {
   let linesOfCode = snippet
     .replace(/\r\n?/g, '\n')
     .replace(/\n{2,}/g, '\n')
@@ -109,23 +109,17 @@ function flourite(
 
   const bestResult = results.reduce((a, b) => (a.points >= b.points ? a : b), { points: 0, language: '' });
   const statistics: Record<string, number> = {};
-  if (options.statistics) {
-    for (let i = 0; i < results.length; i++) {
-      statistics[results[i].language] = results[i].points;
-    }
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return {
-      detected: options.shiki ? convert(bestResult.language) : bestResult.language,
-      statistics,
-    };
+  for (let i = 0; i < results.length; i++) {
+    statistics[results[i].language] = results[i].points;
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  return options.shiki ? convert(bestResult.language) : bestResult.language;
+  return {
+    language: options.shiki ? convert(bestResult.language) : bestResult.language,
+    statistics,
+    linesOfCode: linesOfCode.length,
+  };
 }
 
-export type { Options, StatisticOutput };
+export type { Options, DetectedLanguage };
 export default flourite;

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,15 +31,16 @@ export interface LanguagePattern {
 
 export interface Options {
   heuristic?: boolean;
-  statistics?: boolean;
   shiki?: boolean;
   noUnknown?: boolean;
 }
 
-export interface StatisticOutput {
-  detected: string;
+export interface DetectedLanguage {
+  language: string;
   statistics: Record<string, number>;
+  linesOfCode: number;
 }
+
 export interface LanguagePoints {
   language: string;
   points: number;

--- a/tests/c.test.ts
+++ b/tests/c.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang('printf("Hello world!\\n");', { shiki: true });
-  assert.equal(code, 'c');
+  assert.equal(code.language, 'c');
 });
 
 test('fizz buzz', () => {
@@ -30,12 +30,12 @@ test('fizz buzz', () => {
   
     return 0;
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('variable declaration', () => {
   const code = detectLang('int *ptr;');
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('file', () => {
@@ -48,7 +48,7 @@ test('file', () => {
   
     return 0;
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('quick sort', () => {
@@ -96,7 +96,7 @@ test('quick sort', () => {
     quicksort(A, i);
     quicksort(A + i, len - i);
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('http server', () => {
@@ -122,7 +122,7 @@ test('http server', () => {
           }
           return EXIT_SUCCESS;
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('fibonacci sequence', () => {
@@ -135,7 +135,7 @@ test('fibonacci sequence', () => {
       }
       return fnext;	
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('bubble sort', () => {
@@ -168,7 +168,7 @@ test('bubble sort', () => {
           printf("%d%s", a[i], i == n - 1 ? "\n" : " ");
       return 0;
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('heap sort', () => {
@@ -222,7 +222,7 @@ test('heap sort', () => {
           printf("%d%s", a[i], i == n - 1 ? "\n" : " ");
       return 0;
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('tree sort on a linked list', () => {
@@ -337,7 +337,7 @@ test('tree sort on a linked list', () => {
       list_destroy(&list);
       return 0;
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('floyd warshall algorithm', () => {
@@ -416,7 +416,7 @@ test('floyd warshall algorithm', () => {
           floydWarshall(loadGraph(argV[1]));
       return 0;
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test('ludic numbers', () => {
@@ -491,7 +491,7 @@ test('ludic numbers', () => {
       free(x);
       return 0;
   }`);
-  assert.equal(code, 'C');
+  assert.equal(code.language, 'C');
 });
 
 test.run();

--- a/tests/clojure.test.ts
+++ b/tests/clojure.test.ts
@@ -5,7 +5,7 @@ import detectLang from '../src/index';
 test('hello world', () => {
   const code = detectLang(`(binding [*out* *err*]
     (println "Goodbye, world!"))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('guess the number', () => {
@@ -19,14 +19,14 @@ test('guess the number', () => {
         (do
          (println "Try again")
          (recur (inc n))))))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('fizz buzz', () => {
   const code = detectLang(
     `(doseq [x (range 1 101)] (println x (str (when (zero? (mod x 3)) "fizz") (when (zero? (mod x 5)) "buzz"))))`,
   );
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('bubble sort', () => {
@@ -57,7 +57,7 @@ test('bubble sort', () => {
      (recur less? result)))))
    
   (println (bubble-sort [10 9 8 7 6 5 4 3 2 1]))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('heap sort', () => {
@@ -88,7 +88,7 @@ test('heap sort', () => {
        (heapify pred a len)))
     ([a]
        (heap-sort a <)))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('merge sort', () => {
@@ -105,7 +105,7 @@ test('merge sort', () => {
       list
       (let [[left right] (split-at (/ (count list) 2) list)]
         (merge (merge-sort left) (merge-sort right)))))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('quick sort', () => {
@@ -115,7 +115,7 @@ test('quick sort', () => {
         (lazy-cat (qsort (filter smaller xs))
       [pivot]
       (qsort (remove smaller xs))))))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('is string numeric?', () => {
@@ -126,7 +126,7 @@ test('is string numeric?', () => {
             s (if (= (first s) \\.) (next s) s)
             s (drop-while #(Character/isDigit %) s)]
         (empty? s))))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('palindrome', () => {
@@ -135,7 +135,7 @@ test('palindrome', () => {
       (or (>= front back)
           (and (= (.charAt s front) (.charAt s back))
                (recur (inc front) (dec back)))))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('ludic numbers', () => {
@@ -164,7 +164,7 @@ test('ludic numbers', () => {
   (print "Triplets < 250: ")
   (println (filter (partial every? ludic?) 
            (for [i (range 250)] (list i (+ i 2) (+ i 6)))))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('date manipulation', () => {
@@ -179,7 +179,7 @@ test('date manipulation', () => {
     long
     (Date. ,)
     (->> , (.format sdf ,)))))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('perfect shuffle', () => {
@@ -195,7 +195,7 @@ test('perfect shuffle', () => {
         (inc (some identity (map-indexed (fn [i x] (when (predicate x) i)) trials)))))))
    
   (map solve [8 24 52 100 1020 1024 10000])`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('conditional', () => {
@@ -205,7 +205,7 @@ test('conditional', () => {
   (cond
     (= 1 2) :no
     (= 1 1) :yes)`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('currying', () => {
@@ -213,7 +213,7 @@ test('currying', () => {
   (assert (= 
              (plus-a-hundred 1)
              101))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('100 doors', () => {
@@ -230,12 +230,12 @@ test('100 doors', () => {
     (println 
       "Open doors after 100 passes:"
       (apply str (interpose ", " (open-doors)))))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('looooop', () => {
   const code = detectLang(`(doseq [s (map #(str %1 %2 %3) "abc" "ABC" "123")])`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test('nested loop', () => {
@@ -256,7 +256,7 @@ test('nested loop', () => {
         (when rs (recur rs)))))
    
   (print-matrix (create-matrix 10 10))`);
-  assert.equal(code, 'Clojure');
+  assert.equal(code.language, 'Clojure');
 });
 
 test.run();

--- a/tests/cpp.test.ts
+++ b/tests/cpp.test.ts
@@ -1,15 +1,13 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import detectLang from '../src/index';
-import type { StatisticOutput } from '../src/types';
 
 test('hello world', () => {
   const code = detectLang('cout << "Hello world" << endl;', {
     shiki: true,
-    statistics: true,
     heuristic: true,
-  }) as StatisticOutput;
-  assert.equal(code.detected, 'cpp');
+  });
+  assert.equal(code.language, 'cpp');
   assert.equal(code.statistics, {
     C: 0,
     Clojure: 0,
@@ -33,6 +31,7 @@ test('hello world', () => {
     Unknown: 1,
     YAML: 0,
   });
+  assert.equal(code.linesOfCode, 1);
 });
 
 test('fizz buzz', () => {
@@ -77,7 +76,7 @@ test('fizz buzz', () => {
    FizzBuzz<100> p;
    return 0;
  }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test('quick sort', () => {
@@ -175,7 +174,7 @@ test('quick sort', () => {
   {
     quicksort(first, last, std::less<typename std::iterator_traits<RandomAccessIterator>::value_type>());
   }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test('bubble sort', () => {
@@ -203,7 +202,7 @@ test('bubble sort', () => {
     copy(std::begin(a), std::end(a), std::ostream_iterator<int>(std::cout, " "));
     std::cout << "\n";
   }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test('heap sort', () => {
@@ -223,7 +222,7 @@ test('heap sort', () => {
     copy(std::begin(a), std::end(a), std::ostream_iterator<int>(std::cout, " "));
     std::cout << "\n";
   }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 // FIXME: This detected as C.
@@ -266,7 +265,7 @@ test.skip('http server', () => {
    
     return 0;
   }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test('floyd warshall algorithm', () => {
@@ -344,7 +343,7 @@ test('floyd warshall algorithm', () => {
     std::cin.get();
     return 0;
   }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test('ludic numbers', () => {
@@ -429,7 +428,7 @@ test('ludic numbers', () => {
       cout << "\n\n";
       return system( "pause" );
   }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test('happy numbers', () => {
@@ -469,7 +468,7 @@ test('happy numbers', () => {
         std::cout << i << std::endl;
     return 0;
   }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test('gamma function', () => {
@@ -532,7 +531,7 @@ test('gamma function', () => {
       }
   }
    `);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test('fivenum', () => {
@@ -615,7 +614,7 @@ test('fivenum', () => {
    
       return 0;
   }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test('y combinator', () => {
@@ -662,7 +661,7 @@ test('y combinator', () => {
     std::cout << "fac(10) = " << fac(10) << std::endl;
     return 0;
   }`);
-  assert.equal(code, 'C++');
+  assert.equal(code.language, 'C++');
 });
 
 test.run();

--- a/tests/cs.test.ts
+++ b/tests/cs.test.ts
@@ -1,15 +1,14 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import detectLang from '../src';
-import type { StatisticOutput } from '../src';
 
 test('hello world', () => {
   const code = detectLang(
     `using System;
   Console.WriteLine("Hello world!");`,
-    { shiki: true, statistics: true, heuristic: true },
-  ) as StatisticOutput;
-  assert.equal(code.detected, 'csharp');
+    { shiki: true, heuristic: true },
+  );
+  assert.equal(code.language, 'csharp');
   assert.equal(code.statistics, {
     C: -39,
     Clojure: 0,
@@ -33,6 +32,7 @@ test('hello world', () => {
     Unknown: 1,
     YAML: 0,
   });
+  assert.equal(code.linesOfCode, 2);
 });
 
 test('fizz buzz', () => {
@@ -69,7 +69,7 @@ test('fizz buzz', () => {
           }
       }
   }`);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test('quick sort', () => {
@@ -249,7 +249,7 @@ test('quick sort', () => {
     }
     #endregion
   }`);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test('heap sort', () => {
@@ -329,7 +329,7 @@ test('heap sort', () => {
           HeapSort(s, 0, s.Length, StringComparer.CurrentCultureIgnoreCase);
       }
   }`);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test('bubble sort', () => {
@@ -377,7 +377,7 @@ test('bubble sort', () => {
           }
       }
   }`);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test('merge sort', () => {
@@ -506,7 +506,7 @@ test('merge sort', () => {
     }
     #endregion
   }`);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test('fibonacci sequence', () => {
@@ -525,7 +525,7 @@ test('fibonacci sequence', () => {
       return fibs;
   }
  `);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test('happy numbers', () => {
@@ -578,7 +578,7 @@ test('happy numbers', () => {
           }
       }
   }`);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test('gamma function', () => {
@@ -610,7 +610,7 @@ test('gamma function', () => {
     }
   }
    `);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test('fivenum', () => {
@@ -678,7 +678,7 @@ test('fivenum', () => {
           }
       }
   }`);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test('y combinator', () => {
@@ -705,7 +705,7 @@ test('y combinator', () => {
       }
   }
    `);
-  assert.equal(code, 'C#');
+  assert.equal(code.language, 'C#');
 });
 
 test.run();

--- a/tests/css.test.ts
+++ b/tests/css.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang('.hello-world {\n\tfont-size: 100px;\n}');
-  assert.equal(code, 'CSS');
+  assert.equal(code.language, 'CSS');
 });
 
 test('long', () => {
@@ -24,7 +24,7 @@ test('long', () => {
  abbr[title] {
    border-bottom: 1px dotted;
  }`);
-  assert.equal(code, 'CSS');
+  assert.equal(code.language, 'CSS');
 });
 
 test.run();

--- a/tests/dockerfile.test.ts
+++ b/tests/dockerfile.test.ts
@@ -16,7 +16,7 @@ EXPOSE 8080
 
 CMD ["npm", "start"]`);
 
-  assert.equal(code, 'Dockerfile');
+  assert.equal(code.language, 'Dockerfile');
 });
 
 test('botnet', () => {
@@ -45,7 +45,7 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "BotNet.dll"]`);
 
-  assert.equal(code, 'Dockerfile');
+  assert.equal(code.language, 'Dockerfile');
 });
 
 test('casperjs dockerfile', () => {
@@ -91,7 +91,7 @@ ENTRYPOINT ["casperjs"]
 CMD ["--help"]
 `);
 
-  assert.equal(code, 'Dockerfile');
+  assert.equal(code.language, 'Dockerfile');
 });
 
 test('kafka dockerfile', () => {
@@ -141,7 +141,7 @@ VOLUME ["/kafka"]
 # Use "exec" form so that it runs as PID 1 (useful for graceful shutdown)
 CMD ["start-kafka.sh"]`);
 
-  assert.equal(code, 'Dockerfile');
+  assert.equal(code.language, 'Dockerfile');
 });
 
 test.run();

--- a/tests/go.test.ts
+++ b/tests/go.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang('fmt.Println("Hello world")');
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('fizz buzz', () => {
@@ -38,7 +38,7 @@ test('fizz buzz', () => {
 			fmt.Println(i)
 		}
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('quick sort', () => {
@@ -135,7 +135,7 @@ test('quick sort', () => {
 			}
 			pex(0, len(a)-1)
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('http server', () => {
@@ -155,7 +155,7 @@ test('http server', () => {
 			}
 			io.Copy(os.Stdout, r.Body)
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('bubble sort', () => {
@@ -188,7 +188,7 @@ test('bubble sort', () => {
 					}
 			}
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('heap sort', () => {
@@ -230,7 +230,7 @@ test('heap sort', () => {
 			heapSort(sort.IntSlice(a))
 			fmt.Println("after: ", a)
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('floyd warshall algorithm', () => {
@@ -347,7 +347,7 @@ test('floyd warshall algorithm', () => {
 			}
 		}
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('ludic numbers', () => {
@@ -432,7 +432,7 @@ test('ludic numbers', () => {
 		}
 		fmt.Println()
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('gamma function', () => {
@@ -463,7 +463,7 @@ test('gamma function', () => {
 					1.5056327351493116e-7/(z+7)
 			return math.Sqrt2 * math.SqrtPi * math.Pow(t, z-.5) * math.Exp(-t) * x
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('fivenum', () => {
@@ -504,7 +504,7 @@ test('fivenum', () => {
 			fmt.Println(fivenum(x2))
 			fmt.Println(fivenum(x3))
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test('y combinator', () => {
@@ -549,7 +549,7 @@ test('y combinator', () => {
 			return f(x-1)+f(x-2)
 		}
 	}`);
-  assert.equal(code, 'Go');
+  assert.equal(code.language, 'Go');
 });
 
 test.run();

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang('<h1>Hello world</h1>');
-  assert.equal(code, 'HTML');
+  assert.equal(code.language, 'HTML');
 });
 
 test('page', () => {
@@ -19,7 +19,7 @@ test('page', () => {
     </body>
   </html>
   `);
-  assert.equal(code, 'HTML');
+  assert.equal(code.language, 'HTML');
 });
 
 test('animation - html+js', () => {
@@ -47,7 +47,7 @@ test('animation - html+js', () => {
   </head> <body onload="animate('target')">
     <pre id="target">Hello World! </pre>
   </body> </html>`);
-  assert.equal(code, 'HTML');
+  assert.equal(code.language, 'HTML');
 });
 
 test('quine - html+css', () => {
@@ -80,12 +80,12 @@ test('quine - html+css', () => {
   </head>
   <body></body>
   </html>`);
-  assert.equal(code, 'HTML');
+  assert.equal(code.language, 'HTML');
 });
 
 test('comments', () => {
   const code = detectLang(`<!-- a comment -->`);
-  assert.equal(code, 'HTML');
+  assert.equal(code.language, 'HTML');
 });
 
 test.run();

--- a/tests/java.test.ts
+++ b/tests/java.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang('System.out.println("Hello world!");');
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test('fizz buzz', () => {
@@ -21,17 +21,17 @@ test('fizz buzz', () => {
       System.out.println();
     }
   }`);
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test('getter/setter', () => {
   const code = detectLang('Person person = people.get(0);');
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test('List/ArrayList', () => {
   const code = detectLang('List<String> things = new ArrayList<>();');
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test('quick sort', () => {
@@ -66,7 +66,7 @@ test('quick sort', () => {
     }
   }
   `);
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test('bubble sort', () => {
@@ -84,7 +84,7 @@ test('bubble sort', () => {
         }
     } while (changed);
   }`);
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test('http server', () => {
@@ -107,7 +107,7 @@ test('http server', () => {
                   .join();
       }
   }`);
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test('floyd warshall algorithm', () => {
@@ -169,7 +169,7 @@ test('floyd warshall algorithm', () => {
           }
       }
   }`);
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test('ludic numbers', () => {
@@ -218,7 +218,7 @@ test('ludic numbers', () => {
       System.out.println("Triplets up to 250: " + getTriplets(ludicUpTo(250)));
     }
   }`);
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test('fivenum', () => {
@@ -264,7 +264,7 @@ test('fivenum', () => {
           for (double[] x : xl) System.out.printf("%s\n\n", Arrays.toString(fivenum(x)));
       }
   }`);
-  assert.equal(code, 'Java');
+  assert.equal(code.language, 'Java');
 });
 
 test.run();

--- a/tests/javascript.test.ts
+++ b/tests/javascript.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang('console.log("Hello world!");');
-  assert.equal(code, 'Javascript');
+  assert.equal(code.language, 'Javascript');
 });
 
 test('fizz buzz', () => {
@@ -16,7 +16,7 @@ test('fizz buzz', () => {
       }),
   );
   `);
-  assert.equal(code, 'Javascript');
+  assert.equal(code.language, 'Javascript');
 });
 
 test('quick sort', () => {
@@ -59,7 +59,7 @@ test('quick sort', () => {
    
     return array;
   }`);
-  assert.equal(code, 'Javascript');
+  assert.equal(code.language, 'Javascript');
 });
 
 test('bubble sort', () => {
@@ -76,7 +76,7 @@ test('bubble sort', () => {
     }
     return this;
   }`);
-  assert.equal(code, 'Javascript');
+  assert.equal(code.language, 'Javascript');
 });
 
 test('heap sort', () => {
@@ -120,7 +120,7 @@ test('heap sort', () => {
       heapSort(arr)
       expect(arr).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
   })`);
-  assert.equal(code, 'Javascript');
+  assert.equal(code.language, 'Javascript');
 });
 
 test('http server', () => {
@@ -143,7 +143,7 @@ test('http server', () => {
   }).on("error", (err) => {
     console.log("Error: " + err.message);
   });`);
-  assert.equal(code, 'Javascript');
+  assert.equal(code.language, 'Javascript');
 });
 
 test('ludic numbers', () => {
@@ -212,7 +212,7 @@ test('ludic numbers', () => {
      console.log([e, e + 2, e + 6].join(', '));
    }
  });`);
-  assert.equal(code, 'Javascript');
+  assert.equal(code.language, 'Javascript');
 });
 
 test('gamma function', () => {
@@ -236,7 +236,7 @@ test('gamma function', () => {
  
     return Math.sqrt(2 * Math.PI) * Math.pow(t, x + 0.5) * Math.exp(-t) * a;
 }`);
-  assert.equal(code, 'Javascript');
+  assert.equal(code.language, 'Javascript');
 });
 
 test('fivenum', () => {
@@ -269,7 +269,7 @@ test('fivenum', () => {
            0.63905160,  0.61501527, -0.98983780, -1.00447874, -0.62759469,
            0.66206163,  1.04312009, -0.10305385,  0.75775634,  0.32566578];
   console.log( test.fiveNums() );`);
-  assert.equal(code, 'Javascript');
+  assert.equal(code.language, 'Javascript');
 });
 
 test.run();

--- a/tests/julia.test.ts
+++ b/tests/julia.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang(`println("Hello world!")`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('fizz buzz', () => {
@@ -19,7 +19,7 @@ test('fizz buzz', () => {
         println(i)
     end
   end`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('fibonacci sequence', () => {
@@ -28,7 +28,7 @@ test('fibonacci sequence', () => {
     for i = 1:n x,y = (y, x+y) end
     x
   end`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('http server', () => {
@@ -37,7 +37,7 @@ test('http server', () => {
       "Goodbye, World!"
   end
   run(server, 8080)`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('palindrome detection', () => {
@@ -51,7 +51,7 @@ test('palindrome detection', () => {
     end
     return false
   end`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('quick sort', () => {
@@ -77,7 +77,7 @@ test('quick sort', () => {
     end
     return A
   end`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('bubble sort', () => {
@@ -92,7 +92,7 @@ test('bubble sort', () => {
 
   v = rand(-10:10, 10)
   println("# unordered: $v\n -> ordered: ", bubblesort!(v))`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('heap sort', () => {
@@ -138,7 +138,7 @@ test('heap sort', () => {
   a = shuffle(collect(1:12))
   println("Unsorted: $a")
   println("Heap sorted: ", heapsort!(a))`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('tree sort on a linked list', () => {
@@ -185,7 +185,7 @@ test('tree sort on a linked list', () => {
   end
 
   testtreesort(rand(1:99, 12))`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('ludic numbers', () => {
@@ -251,7 +251,7 @@ test('ludic numbers', () => {
     println("    ", i, ", ", j, ", ", k)
   end
   `);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('floyd warshall algorithm', () => {
@@ -293,7 +293,7 @@ test('floyd warshall algorithm', () => {
   end
    
   floydwarshall([1 3 -2; 2 1 4; 2 3 3; 3 4 2; 4 2 -1], 4)`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test('fivenum', () => {
@@ -325,7 +325,7 @@ for v in ([15.0, 6.0, 42.0, 41.0, 7.0, 36.0, 49.0, 40.0, 39.0, 47.0, 43.0],
          0.75775634,  0.32566578])
   println("# ", v, "\n -> ", fivenum(v))
 end`);
-  assert.equal(code, 'Julia');
+  assert.equal(code.language, 'Julia');
 });
 
 test.run();

--- a/tests/kotlin.test.ts
+++ b/tests/kotlin.test.ts
@@ -6,7 +6,7 @@ test('hello world', () => {
   const code = detectLang(`fun main(args: Array<String>) {
     println("Goodbye, World!")
 }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('fizz buzz', () => {
@@ -38,7 +38,7 @@ test('fizz buzz', () => {
             println(i)
     }
 }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('guess the number', () => {
@@ -50,7 +50,7 @@ test('guess the number', () => {
     do { print(" Your guess : ") } while (n != readLine())
     println("\\nWell guessed!")
   }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('date manipulation', () => {
@@ -71,7 +71,7 @@ test('date manipulation', () => {
       cal.timeZone = TimeZone.getTimeZone("MST")
       println(fmt.format(cal))
   }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('humble numbers', () => {
@@ -115,7 +115,7 @@ fun main() {
         }
     }
 }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('attractive number', () => {
@@ -171,7 +171,7 @@ test('attractive number', () => {
       }
       println()
   }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('bubble sort', () => {
@@ -191,7 +191,7 @@ test('bubble sort', () => {
           }
       } while (changed)
   }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('heap sort', () => {
@@ -241,7 +241,7 @@ fun main(args: Array<String>) {
         println(a.joinToString(", "))
     }
 }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('merge sort', () => {
@@ -295,7 +295,7 @@ fun main(args: Array<String>) {
     println("Unsorted: $numbers")
     println("Sorted: \${mergeSort(numbers)}")
 }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('palindrome', () => {
@@ -328,7 +328,7 @@ test('palindrome', () => {
           println("'$candidate' is \${if (isInexactPalindrome(candidate)) "an" else "not an"} inexact palindrome")
       }
   }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('floyd warshall', () => {
@@ -388,7 +388,7 @@ fun main(args: Array<String>) {
     val nVertices = 4
     FloydWarshall.doCalcs(weights, nVertices)
 }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('most frequent k chair distance', () => {
@@ -444,7 +444,7 @@ fun main(args: Array<String>) {
   s2 = s1.reversed()
   mostFreqKSDF(s1, s2, 2, 100)
 }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test('bankers algorithm', () => {
@@ -515,7 +515,7 @@ test('bankers algorithm', () => {
         println("\\nAvailable Vector: \${avl.joinToString(" ")}")
     }
 }`);
-  assert.equal(code, 'Kotlin');
+  assert.equal(code.language, 'Kotlin');
 });
 
 test.run();

--- a/tests/large.test.ts
+++ b/tests/large.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import detectLang, { StatisticOutput } from '../src';
+import detectLang from '../src';
 
 test('large input', () => {
   // This is the code of argon2
@@ -654,9 +654,9 @@ test('large input', () => {
   
       return ARGON2_OK;
   }`,
-    { heuristic: true, statistics: true },
-  ) as StatisticOutput;
-  assert.equal(code.detected, 'C++');
+    { heuristic: true },
+  );
+  assert.equal(code.language, 'C++');
   assert.equal(code.statistics, {
     C: 111,
     Clojure: 0,
@@ -680,6 +680,7 @@ test('large input', () => {
     Unknown: 1,
     YAML: 4,
   });
+  assert.equal(code.linesOfCode, 356);
 });
 
 test.run();

--- a/tests/lua.test.ts
+++ b/tests/lua.test.ts
@@ -8,19 +8,19 @@ test('local definition', () => {
     local some_var = 12
     local table = {1, 2, "foo"} `,
   );
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('array-like tables', () => {
   const code = detectLang(`{1212, "foo", 'bar', true, false, nil}`);
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('map-like tables', () => {
   const code = detectLang(`{foo = "bar", [0] = false, ["true"] = 1212}`);
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('metatable definition', () => {
@@ -30,7 +30,7 @@ test('metatable definition', () => {
     __add = function(x, y) return x + y end
   })`);
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('functiopn call', () => {
@@ -46,7 +46,7 @@ test('functiopn call', () => {
     foo{...}
   `);
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('http', () => {
@@ -58,7 +58,7 @@ test('http', () => {
       print(page)`,
   );
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('fizzbuzz', () => {
@@ -76,7 +76,7 @@ test('fizzbuzz', () => {
       end`,
   );
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('fibonacci sequence', () => {
@@ -84,7 +84,7 @@ test('fibonacci sequence', () => {
   function fibs(n) 
     return n < 2 and n or fibs(n - 1) + fibs(n - 2) 
   end`);
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('quicksort', () => {
@@ -111,7 +111,7 @@ test('quicksort', () => {
   --example
   print(unpack(quicksort{5, 2, 7, 3, 4, 7, 1}))`);
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('floyd warshall', () => {
@@ -181,7 +181,7 @@ test('floyd warshall', () => {
   numVertices = 4
   floydWarshall(weights, numVertices)`);
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('bubble sort', () => {
@@ -206,7 +206,7 @@ test('bubble sort', () => {
       print(j)
   end`);
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('ludic numbers', () => {
@@ -257,7 +257,7 @@ test('ludic numbers', () => {
   show("2000th to 2005th:", inRange)
   show("Triplets:", triplets)`);
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('lsp handler', () => {
@@ -276,7 +276,7 @@ test('lsp handler', () => {
     end
   `,
   );
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('yes, this is a valid lua code', () => {
@@ -298,7 +298,7 @@ test('yes, this is a valid lua code', () => {
 }`,
   );
 
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test('fivenum', () => {
@@ -354,7 +354,7 @@ x1 = {
 for i,x in ipairs(x1) do
   print(fivenum(x))
 end`);
-  assert.equal(code, 'Lua');
+  assert.equal(code.language, 'Lua');
 });
 
 test.run();

--- a/tests/pascal.test.ts
+++ b/tests/pascal.test.ts
@@ -8,7 +8,7 @@ test('hello world', () => {
   begin
     writeln(StdErr, 'Goodbye, World!');
   end.`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('fizz buzz', () => {
@@ -26,7 +26,7 @@ test('fizz buzz', () => {
       else
         writeln(i);
   end.`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('guess the number', () => {
@@ -50,7 +50,7 @@ test('guess the number', () => {
     writeln ('You made an excellent guess. Thank you and have a nice day.');
   end.
    `);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('bubble sort', () => {
@@ -69,7 +69,7 @@ test('bubble sort', () => {
           list[j + 1] := t;
         end;
   end;`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('heap sort', () => {
@@ -150,7 +150,7 @@ test('heap sort', () => {
     end;
     writeln;
   end.`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('merge sort', () => {
@@ -242,7 +242,7 @@ test('merge sort', () => {
     end;
     writeln;
   end.`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('quick sort', () => {
@@ -269,7 +269,7 @@ test('quick sort', () => {
     If Left<j Then QuickSort(Left,j);
     If i<Right Then QuickSort(i,Right);
   End;`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('palindrome', () => {
@@ -296,7 +296,7 @@ test('palindrome', () => {
      else
         is_palindro := false
   end;`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('happy numbers', () => {
@@ -361,7 +361,7 @@ test('happy numbers', () => {
     end;
     writeln;
   end.`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('ludic numbers', () => {
@@ -509,7 +509,7 @@ test('ludic numbers', () => {
     LastLucid(LudicList,maxLudicCnt,5);
     triples(LudicList,250);//all-> (LudicList,LudicList[High(LudicList)].dNum);
   END.`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test('attractive number', () => {
@@ -723,7 +723,7 @@ test('attractive number', () => {
     writeln('time counting : ',T*86400 :8:3,' s');
     writeln('time total    : ',(now-T0)*86400 :8:3,' s');
   end.`);
-  assert.equal(code, 'Pascal');
+  assert.equal(code.language, 'Pascal');
 });
 
 test.run();

--- a/tests/php.test.ts
+++ b/tests/php.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang('echo "Hello world";');
-  assert.equal(code, 'PHP');
+  assert.equal(code.language, 'PHP');
 });
 
 test('fizz buzz', () => {
@@ -25,7 +25,7 @@ test('fizz buzz', () => {
   
     echo "\n";
   }`);
-  assert.equal(code, 'PHP');
+  assert.equal(code.language, 'PHP');
 });
 
 test('sql based authentication', () => {
@@ -99,7 +99,7 @@ test('sql based authentication', () => {
     // Return the record ID
     return $row['userid'];
   }`);
-  assert.equal(code, 'PHP');
+  assert.equal(code.language, 'PHP');
 });
 
 test('quick sort', () => {
@@ -123,7 +123,7 @@ test('quick sort', () => {
   $arr = array(1, 3, 5, 7, 9, 8, 6, 4, 2);
   $arr = quicksort($arr);
   echo implode(',',$arr);`);
-  assert.equal(code, 'PHP');
+  assert.equal(code.language, 'PHP');
 });
 
 test('bubble sort', () => {
@@ -140,7 +140,7 @@ test('bubble sort', () => {
     }
     return $array;
   }`);
-  assert.equal(code, 'PHP');
+  assert.equal(code.language, 'PHP');
 });
 
 test('merge sort', () => {
@@ -179,7 +179,7 @@ test('merge sort', () => {
   $arr = array( 1, 5, 2, 7, 3, 9, 4, 6, 8);
   $arr = mergesort($arr);
   echo implode(',',$arr);`);
-  assert.equal(code, 'PHP');
+  assert.equal(code.language, 'PHP');
 });
 
 test('bogo sort', () => {
@@ -195,7 +195,7 @@ test('bogo sort', () => {
               return FALSE;
       return TRUE;
   }`);
-  assert.equal(code, 'PHP');
+  assert.equal(code.language, 'PHP');
 });
 
 test('floyd warshall algorithm', () => {
@@ -222,7 +222,7 @@ test('floyd warshall algorithm', () => {
    
   print_r($graph);
   ?>`);
-  assert.equal(code, 'PHP');
+  assert.equal(code.language, 'PHP');
 });
 
 test.run();

--- a/tests/python.test.ts
+++ b/tests/python.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang('print "Hello world!"');
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('fizz buzz', () => {
@@ -22,12 +22,12 @@ test('fizz buzz', () => {
 		return str(n)
  
 print "\n".join(fizzbuzz(n) for n in xrange(0, 100))`);
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('variable declaration', () => {
   const code = detectLang('i = 1');
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('quick sort', () => {
@@ -52,7 +52,7 @@ test('quick sort', () => {
 
 a = [4, 65, 2, -31, 0, 99, 83, 782, 1]
 a = quickSort(a)`);
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('bubble sort', () => {
@@ -82,7 +82,7 @@ if __name__ == "__main__":
  assert testcase != testset  # we've shuffled it
  bubble_sort(testcase)
  assert testcase == testset  # we've unshuffled it back into a copy`);
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('heap sort', () => {
@@ -110,7 +110,7 @@ def siftdown(lst, start, end):
       root = child
     else:
       break`);
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('http server', () => {
@@ -121,7 +121,7 @@ test('http server', () => {
 	# Alternatively, you can use connect(), followed by the putrequest, putheader and endheaders functions.
 	result = conn.getresponse()
 	r1 = result.read() # This retrieves the entire contents.  `);
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('floyd warshall algorithm', () => {
@@ -154,7 +154,7 @@ test('floyd warshall algorithm', () => {
 		
 		if __name__ == '__main__':
 				floyd_warshall(4, [[1, 3, -2], [2, 1, 4], [2, 3, 3], [3, 4, 2], [4, 2, -1]])`);
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('ludic numbers', () => {
@@ -180,7 +180,7 @@ test('ludic numbers', () => {
 						if x+6 < n and x+2 in ludics and x+6 in ludics]
 	print('\nThere are %i triplets less than %i:\n  %r'
 			% (len(triplets), n, triplets))`);
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('gamma function', () => {
@@ -266,7 +266,7 @@ test('gamma function', () => {
 	# MAIN ---
 	if __name__ == '__main__':
 			main()`);
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test('fivenum', () => {
@@ -298,7 +298,7 @@ test('fivenum', () => {
 	 
 	y = fivenum(x)
 	print(y)`);
-  assert.equal(code, 'Python');
+  assert.equal(code.language, 'Python');
 });
 
 test.run();

--- a/tests/ruby.test.ts
+++ b/tests/ruby.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang('puts "Hello world"');
-  assert.equal(code, 'Ruby');
+  assert.equal(code.language, 'Ruby');
 });
 
 test('fizz buzz', () => {
@@ -19,7 +19,7 @@ test('fizz buzz', () => {
       puts i
   end
 end`);
-  assert.equal(code, 'Ruby');
+  assert.equal(code.language, 'Ruby');
 });
 
 // FIXME: This detects as Java. It should be Ruby.
@@ -32,7 +32,7 @@ test.skip('quick sort', () => {
     less.quick_sort + [pivot] + greatereq.quick_sort
   end
 end`);
-  assert.equal(code, 'Ruby');
+  assert.equal(code.language, 'Ruby');
 });
 
 test('bubble sort', () => {
@@ -59,7 +59,7 @@ test('bubble sort', () => {
   ary = [3, 78, 4, 23, 6, 8, 6]
   ary.bubblesort1!
   p ary`);
-  assert.equal(code, 'Ruby');
+  assert.equal(code.language, 'Ruby');
 });
 
 // FIXME: Detected as Python
@@ -98,7 +98,7 @@ test.skip('heap sort', () => {
       end
     end
   end`);
-  assert.equal(code, 'Ruby');
+  assert.equal(code.language, 'Ruby');
 });
 
 // FIXME: This detected as PHP
@@ -107,7 +107,7 @@ test.skip('http server', () => {
   require 'open-uri'
    
   open("http://rosettacode.org/") {|f| FileUtils.copy_stream(f, $stdout)}`);
-  assert.equal(code, 'Ruby');
+  assert.equal(code.language, 'Ruby');
 });
 
 test('floyd warshall algorithm', () => {
@@ -146,7 +146,7 @@ test('floyd warshall algorithm', () => {
   n = 4
   edge = [[1, 3, -2], [2, 1, 4], [2, 3, 3], [3, 4, 2], [4, 2, -1]]
   floyd_warshall(n, edge)`);
-  assert.equal(code, 'Ruby');
+  assert.equal(code.language, 'Ruby');
 });
 
 test('ludic numbers', () => {
@@ -171,7 +171,7 @@ test('ludic numbers', () => {
   ludics = ludic(250).to_a
   puts "Ludic triples below 250:",
       ludics.select{|x| ludics.include?(x+2) and ludics.include?(x+6)}.map{|x| [x, x+2, x+6]}.to_s`);
-  assert.equal(code, 'Ruby');
+  assert.equal(code.language, 'Ruby');
 });
 
 test('fivenum', () => {
@@ -202,7 +202,7 @@ test_array = [0.14082834, 0.09748790, 1.73131507, 0.87636009, -1.95059594,
 tukey_array = fivenum(test_array)
 p tukey_array
  `);
-  assert.equal(code, 'Ruby');
+  assert.equal(code.language, 'Ruby');
 });
 
 test.run();

--- a/tests/rust.test.ts
+++ b/tests/rust.test.ts
@@ -6,7 +6,7 @@ test('hello world', () => {
   const code = detectLang(`fn main() {
     print!("Hello world!");
  }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('fizz buzz', () => {
@@ -20,7 +20,7 @@ test('fizz buzz', () => {
         }
     }
 }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('quick sort', () => {
@@ -77,7 +77,7 @@ test('quick sort', () => {
       v.swap(store_index, len - 1);
       store_index
   }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('http', () => {
@@ -96,7 +96,7 @@ test('http', () => {
       println!("{}", body);
   }
    `);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('fibonacci sequence', () => {
@@ -109,7 +109,7 @@ test('fibonacci sequence', () => {
     }
     fib_tail_iter(nth, 0, 1)
   }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('palindrome detection', () => {
@@ -138,7 +138,7 @@ test('palindrome detection', () => {
           "The quick brown fox"
       );
   }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('file input', () => {
@@ -170,7 +170,7 @@ test('file input', () => {
       writeln!(&mut io::stderr(), "ERROR: {}", msg).expect("Could not write to stdout");
       process::exit(code);
   }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('bubble sort', () => {
@@ -207,7 +207,7 @@ test('bubble sort', () => {
       bubble_sort(&mut strings);
       println!("After: {:?}", strings);
   }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('heap sort', () => {
@@ -254,7 +254,7 @@ test('heap sort', () => {
           }
       }
   }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('ludic number', () => {
@@ -356,7 +356,7 @@ test('ludic number', () => {
       }
   }
    `);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('floyd warshall algorithm', () => {
@@ -573,7 +573,7 @@ test('floyd warshall algorithm', () => {
       // Fixup the vertex name (as we use zero-based indices)
       print_results(&weights, paths.as_ref(), |index| index + 1);
   }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test('fivenum', () => {
@@ -649,7 +649,7 @@ test('fivenum', () => {
             println!("  Maximum: {}", result.maximum);
         }
     }`);
-  assert.equal(code, 'Rust');
+  assert.equal(code.language, 'Rust');
 });
 
 test.run();

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -4,7 +4,7 @@ import detectLang from '../src/index';
 
 test('hello world', () => {
   const code = detectLang(`SELECT 'Hello world!' text FROM dual;`);
-  assert.equal(code, 'SQL');
+  assert.equal(code.language, 'SQL');
 });
 
 test('fizz buzz', () => {
@@ -32,7 +32,7 @@ test('fizz buzz', () => {
   -- Tidy up
   DROP TABLE fizzbuzz;
   DROP TABLE numbers;`);
-  assert.equal(code, 'SQL');
+  assert.equal(code.language, 'SQL');
 });
 
 test('date manipulation', () => {
@@ -68,7 +68,7 @@ test('date manipulation', () => {
   INTERVAL '12' HOUR)
   at TIME zone 'US/Arizona' plus_12_nodst
   FROM dual;`);
-  assert.equal(code, 'SQL');
+  assert.equal(code.language, 'SQL');
 });
 
 test('merge and aggregate', () => {
@@ -131,7 +131,7 @@ test('merge and aggregate', () => {
     p.LASTNAME
   ORDER BY
     p.PATIENT_ID;`);
-  assert.equal(code, 'SQL');
+  assert.equal(code.language, 'SQL');
 });
 
 test('fibonacci sequence', () => {
@@ -139,7 +139,7 @@ test('fibonacci sequence', () => {
   ) OVER ( ORDER BY level ) ) / SQRT( 5 ) ) fibo
 FROM dual
 CONNECT BY level <= 10;`);
-  assert.equal(code, 'SQL');
+  assert.equal(code.language, 'SQL');
 });
 
 test('integer comparison', () => {
@@ -154,7 +154,7 @@ test('integer comparison', () => {
   SELECT to_char(a)||' is greater than '||to_char(b) greater_than
   FROM test
   WHERE a > b;`);
-  assert.equal(code, 'SQL');
+  assert.equal(code.language, 'SQL');
 });
 
 test.run();

--- a/tests/unknown.test.ts
+++ b/tests/unknown.test.ts
@@ -3,15 +3,15 @@ import * as assert from 'uvu/assert';
 import detectLang from '../src/index';
 
 test('should detect Unknown', () => {
-  assert.equal(detectLang('Hello world!'), 'Unknown');
+  assert.equal(detectLang('Hello world!').language, 'Unknown');
 });
 
 test('should detect Unknown', () => {
-  assert.equal(detectLang('ooga booga'), 'Unknown');
+  assert.equal(detectLang('ooga booga').language, 'Unknown');
 });
 
 test('should not gives unknown', () => {
-  assert.equal(detectLang('a very random text', { noUnknown: true }), '');
+  assert.equal(detectLang('a very random text', { noUnknown: true }).language, '');
 });
 
 test.run();

--- a/tests/yaml.test.ts
+++ b/tests/yaml.test.ts
@@ -7,7 +7,7 @@ test('simple key value', () => {
 another_key: Another value goes here.
 a_number_value: 100
 scientific_notation: 1e+12`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test('collection', () => {
@@ -20,7 +20,7 @@ a_nested_map:
 
 # Maps don't have to have string keys.
 0.25: a float key`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test('complex key', () => {
@@ -28,7 +28,7 @@ test('complex key', () => {
   This is a key
   that has multiple lines
 : and this is its value`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test('merge key', () => {
@@ -39,7 +39,7 @@ test('merge key', () => {
 bar:
   <<: *base
   age: 20`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test('binary', () => {
@@ -48,7 +48,7 @@ test('binary', () => {
   OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+
   +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC
   AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test('set types', () => {
@@ -57,7 +57,7 @@ test('set types', () => {
   ? item2
   ? item3
 or: {item1, item2, item3}`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test('docker compose file', () => {
@@ -72,7 +72,7 @@ test('docker compose file', () => {
         - "./docker/dynamodb:/home/dynamodblocal/data"
       working_dir: /home/dynamodblocal
       command: "-jar DynamoDBLocal.jar -sharedDb -optimizeDbBeforeStartup -dbPath ./data"`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test('github actions', () => {
@@ -109,7 +109,7 @@ jobs:
         app-name: \${{ env.AZURE_WEBAPP_NAME }}
         publish-profile: \${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
         package: \${{ env.AZURE_WEBAPP_PACKAGE_PATH }}`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test('circleci config', () => {
@@ -209,7 +209,7 @@ workflows:
       - test_prod_node9:
           requires:
             - build_prod`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test('eslint config yaml', () => {
@@ -247,7 +247,7 @@ test('eslint config yaml', () => {
     '@typescript-eslint/no-unused-vars':
       - 2
       - argsIgnorePattern: '^_'`);
-  assert.equal(code, 'YAML');
+  assert.equal(code.language, 'YAML');
 });
 
 test.run();


### PR DESCRIPTION
breaking change for everyone, they now must use .language to get the detected language

- bump dev deps versions
- changed the usage of flourite to:
```js
const code = flourite('printf("Hello World");');

// {
//   language: 'C',
//   statistics: {
//     C: 5,
//     Clojure: 0,
//     'C++': 0,
//     'C#': 0,
//     CSS: 0,
//     Dockerfile: 0,
//     Go: 0,
//     HTML: 0,
//     Java: 0,
//     Javascript: 0,
//     Julia: 0,
//     Kotlin: 0,
//     Lua: -20,
//     Pascal: 0,
//     PHP: 0,
//     Python: 0,
//     Ruby: 0,
//     Rust: 0,
//     SQL: 0,
//     YAML: 0,
//     Unknown: 1
//   },
//   linesOfCode: 1
// }
```
- better typescript support
- no unused code bullshit