### PR TITLE
fix #38: fix backtracking issues in Lua

### DIFF
--- a/src/languages/lua.ts
+++ b/src/languages/lua.ts
@@ -30,7 +30,7 @@ export const Lua: LanguagePattern[] = [
   { pattern: /{\s*[^\s;,]+([;,]\s*[^\s;,]+)*,?\s*}/, type: 'constant.array' },
   // map-like table
   {
-    pattern: /{\s*([^\s;,]+\s*=\s*[^\s;,]+)(\s*[;,]\s*[^\s;,]+\s*=\s*[^\s;,]+)*\s*,?\s*}/,
+    pattern: /{\s*([^\s;,=]+\s*=\s*[^\s;,=]+)(\s*[;,=]\s*[^\s;,=]+\s*=\s*[^\s;,=]+)*\s*,?\s*}/,
     type: 'constant.dictionary',
   },
   // builtin math methods

--- a/src/languages/lua.ts
+++ b/src/languages/lua.ts
@@ -27,9 +27,9 @@ export const Lua: LanguagePattern[] = [
   // method invocation
   { pattern: /(\(.+\)|([a-zA-Z_]+)):([a-zA-Z_])\(.*\)/, type: 'keyword.other' },
   // array-like table
-  { pattern: /{\s*(\S+)((,|;)\s*\S+)*\s*}/, type: 'constant.array' },
+  { pattern: /{\s*[^\s;,]+([;,]\s*[^\s;,]+)*,?\s*}/, type: 'constant.array' },
   // map-like table
-  { pattern: /{\s*(\S+\s*=\s*\S+)((,|;)\s*\S+\s*=\s*\S+)*\s*}/, type: 'constant.dictionary' },
+  { pattern: /{\s*([^\s;,]+\s*=\s*[^\s;,]+)(\s*[;,]\s*[^\s;,]+\s*=\s*[^\s;,]+)*\s*,?\s*}/, type: 'constant.dictionary' },
   // builtin math methods
   { pattern: /math\.(.*)\([0-9]*\)/, type: 'macro' },
   // builtin table methods

--- a/src/languages/lua.ts
+++ b/src/languages/lua.ts
@@ -29,7 +29,10 @@ export const Lua: LanguagePattern[] = [
   // array-like table
   { pattern: /{\s*[^\s;,]+([;,]\s*[^\s;,]+)*,?\s*}/, type: 'constant.array' },
   // map-like table
-  { pattern: /{\s*([^\s;,]+\s*=\s*[^\s;,]+)(\s*[;,]\s*[^\s;,]+\s*=\s*[^\s;,]+)*\s*,?\s*}/, type: 'constant.dictionary' },
+  {
+    pattern: /{\s*([^\s;,]+\s*=\s*[^\s;,]+)(\s*[;,]\s*[^\s;,]+\s*=\s*[^\s;,]+)*\s*,?\s*}/,
+    type: 'constant.dictionary',
+  },
   // builtin math methods
   { pattern: /math\.(.*)\([0-9]*\)/, type: 'macro' },
   // builtin table methods

--- a/tests/large.test.ts
+++ b/tests/large.test.ts
@@ -669,7 +669,7 @@ test('large input', () => {
     Javascript: -452,
     Julia: 24,
     Kotlin: 0,
-    Lua: -1820,
+    Lua: -1823,
     Pascal: 0,
     PHP: -318,
     Python: -140,


### PR DESCRIPTION
fix #38

Seems like overlapping patterns is the cause of this exponential backtracking.
Those patterns are `\S` and `(,|;)` because punctuations are also non-whitespace characters, hence they can be matched by `\S` as well.

I've replaced `\S` with `[^\s;,]` to prevent them from overlapping.
