### PR TITLE
fix #62: minimize incorrect matches for javascript function

### DIFF
--- a/src/languages/javascript.ts
+++ b/src/languages/javascript.ts
@@ -16,7 +16,7 @@ export const Javascript: LanguagePattern[] = [
   // !== operator
   { pattern: /!==/g, type: 'keyword.operator' },
   // Function definition
-  { pattern: /function\*?(\s+[$\w]+\s*\(.*\)|\s*\(.*\))/g, type: 'keyword.function' },
+  { pattern: /function\*?\s*([A-Za-z$_][\w$]*)?\s*[(][^:;()]*[)]\s*{/g, type: 'keyword.function' },
   // arrow function
   { pattern: /\(* => {/g, type: 'keyword.function' },
   // null keyword


### PR DESCRIPTION
Address #47
Fix #62

Before

`function\*?(\s+[$\w]+\s*\(.*\)|\s*\(.*\))`

After

`function\*?\s*([A-Za-z$_][\w$]*)?\s*[(][^:;()]*[)]\s*{`

Replaced patterns:
- Wildcard ( `.` ) 
- Alternation ( `|` ) 
- Escaped meta character  ( `\meta` ) 

This regex enforces the following:
- Function name can't start with a digit
- Parameters can't contain parentheses, colon and semicolon
- There must be an opening curly bracket after the closing parentheses

Known remaining issues:
- Doesn't match if the function name uses valid characters that are outside standard ASCII, e.g., accented letters, emoji, kanji, etc
- Parameter's name is still too permissive, currently it only disallows 4 characters (`(`, `)`, `:`, `;`)
